### PR TITLE
Add types to support TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+declare module 'feedparser-promised' {
+	
+	import { Options } from 'request';
+	import { Item } from 'node-feedparser';
+	
+	export function parse(url: string): Promise<Item[]>;
+	export function parse(options: Options): Promise<Item[]>;
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "feedparser": "^2.1.0",
     "request": "^2.79.0",
     "@types/node-feedparser": "2.2.0",
-    "@types/request": "0.0.43",
+    "@types/request": "0.0.43"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
   "version": "1.2.2",
   "description": "Wrapper around feedparser with promises",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "pretest": "eslint src/** test**",
     "test": "istanbul cover _mocha -- --recursive"
   },
   "dependencies": {
     "feedparser": "^2.1.0",
-    "request": "^2.79.0"
+    "request": "^2.79.0",
+    "@types/node-feedparser": "2.2.0",
+    "@types/request": "0.0.43",
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
I've been using this library for a while with TypeScript, and thought I might as well share my type definitions with others.

The typedefs follows [the official guide](http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) to bundling types with packages.

The types rely on typedefs for the [original feedparser](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/6ae1b1ea58611cd5457424e91335323044e24c72/types/node-feedparser) library, as well as types for the [node request](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/request) library.

- `parse()` can either take an `url: string` as an argument, or HTTP Options which are equivalent to [request's `Options` type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/request/index.d.ts#L140) (as the source code shows the options are directly passed to this dependency).
- In both cases it returns a Promise, resolving to an array of Items [as defined in the feedparser types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6ae1b1ea58611cd5457424e91335323044e24c72/types/node-feedparser/index.d.ts#L150).
- Dependencies for these outside types have been added as locked versions, because we have no way of knowing if future updates to these typedefs will break anything here in.