### PR TITLE
Ability to transfer options to feedparser

### DIFF
--- a/feedparser-options-ext.d.ts
+++ b/feedparser-options-ext.d.ts
@@ -1,0 +1,5 @@
+import { Options } from "feedparser";
+
+export interface FeedparserOptions implements Options {
+    onError?: (message: any) => any;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,10 @@
 declare module 'feedparser-promised' {
-	
-	import { Options } from 'request';
+
+	import { Options as RequestOptions } from 'request';
+	import { Options as FeedparserOptions } from 'feedparser';
 	import { Item } from 'node-feedparser';
-	
+
 	export function parse(url: string): Promise<Item[]>;
-	export function parse(options: Options): Promise<Item[]>;
+	export function parse(requestOptions: RequestOptions): Promise<Item[]>;
+	export function parse(requestOptions: RequestOptions, feedparserOptions: FeedparserOptions): Promise<Item[]>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'feedparser-promised' {
 
-	import { Options as RequestOptions } from 'request';
-	import { Options as FeedparserOptions } from 'feedparser';
+	import { RequestOptions } from './request-options-ext';
+	import { FeedparserOptions } from './feedparser-options-ext';
 	import { Item } from 'node-feedparser';
 
 	export function parse(url: string): Promise<Item[]>;

--- a/request-options-ext.d.ts
+++ b/request-options-ext.d.ts
@@ -1,0 +1,5 @@
+import { Options } from 'request';
+
+export interface RequestOptions implements Options {
+    onError?: (message: any) => any;
+}

--- a/src/feedParserPromised.js
+++ b/src/feedParserPromised.js
@@ -4,10 +4,10 @@ const request = require('request');
 const FeedParser = require('feedparser');
 
 module.exports = class FeedParserPromised {
-  static parse (options) {
+  static parse (requestOptions, feedparserOptions) {
     return new Promise( (resolve, reject) => {
       const items = [];
-      const feedparser = new FeedParser();
+      const feedparser = new FeedParser(feedparserOptions);
 
       feedparser.on('error', (err) => { reject(err); });
 
@@ -19,7 +19,7 @@ module.exports = class FeedParserPromised {
         return items;
       });
 
-      request.get(options)
+      request.get(requestOptions)
         .on('error', (err) => { reject(err); })
         .pipe(feedparser)
         .on('end', () => { return resolve(items); });

--- a/src/feedParserPromised.js
+++ b/src/feedParserPromised.js
@@ -9,7 +9,11 @@ module.exports = class FeedParserPromised {
       const items = [];
       const feedparser = new FeedParser(feedparserOptions);
 
-      feedparser.on('error', (err) => { reject(err); });
+      if (feedparserOptions.onError) {
+        feedparser.on('error', feedparserOptions.onError);
+      } else {
+        feedparser.on('error', (err) => { reject(err); });
+      }
 
       feedparser.on('readable', () => {
         let item;


### PR DESCRIPTION
In addition to the ability to pass options to the `request`, I added the ability to pass options to the `feedparser`. It was necessary for me in my project and I decided to share it.