### PR TITLE
Ability to transfer options to feedparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,33 @@ Wrapper around [feedparser](https://github.com/danmactough/node-feedparser) with
 ```javascript
 const feedparser = require('feedparser-promised');
 
-const options = {
+const httpOptions = {
   uri: 'http://feeds.feedwrench.com/JavaScriptJabber.rss',
   timeout: 3000,
   gzip: true,
   // ...
 };
 
-feedparser.parse(options).then( (items) => { /* do your magic here */ });
+feedparser.parse(httpOptions).then( (items) => { /* do your magic here */ });
+```
+
+## Using [Feedparser](https://github.com/danmactough/node-feedparser#options) options
+```javascript
+const feedparser = require('feedparser-promised');
+
+const httpOptions = {
+  uri: 'http://feeds.feedwrench.com/JavaScriptJabber.rss',
+  // ...
+};
+
+const feedparserOptions = {
+  feedurl: 'http://feeds.feedwrench.com/JavaScriptJabber.rss',
+  normalize: false,
+  addmeta: false,
+  resume_saxerror: true
+};
+
+feedparser.parse(httpOptions, feedparserOptions).then( (items) => { /* do your magic here */ });
 ```
 
 ### List of article properties

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,10 @@
 declare module 'feedparser-promised' {
-	
-	import { Options } from 'request';
+
+	import { Options as RequestOptions } from 'request';
+	import { Options as FeedparserOptions } from 'feedparser';
 	import { Item } from 'node-feedparser';
-	
+
 	export function parse(url: string): Promise<Item[]>;
-	export function parse(options: Options): Promise<Item[]>;
+	export function parse(requestOptions: RequestOptions): Promise<Item[]>;
+	export function parse(requestOptions: RequestOptions, feedparserOptions: FeedparserOptions): Promise<Item[]>;
 }

--- a/src/feedParserPromised.js
+++ b/src/feedParserPromised.js
@@ -4,10 +4,10 @@ const request = require('request');
 const FeedParser = require('feedparser');
 
 module.exports = class FeedParserPromised {
-  static parse (options) {
+  static parse (requestOptions, feedparserOptions) {
     return new Promise( (resolve, reject) => {
       const items = [];
-      const feedparser = new FeedParser();
+      const feedparser = new FeedParser(feedparserOptions);
 
       feedparser.on('error', (err) => { reject(err); });
 
@@ -19,7 +19,7 @@ module.exports = class FeedParserPromised {
         return items;
       });
 
-      request.get(options)
+      request.get(requestOptions)
         .on('error', (err) => { reject(err); })
         .pipe(feedparser)
         .on('end', () => { return resolve(items); });


### PR DESCRIPTION
In addition to the ability to pass options to the `request`, I added the ability to pass options to the `feedparser`. It was necessary for me in my project and I decided to share it.